### PR TITLE
Terraform hotfix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 #создаем
 
 module "test-vm" {
-  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source          = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=e801fb6"
   env_name        = "develop"
   network_id      = module.network.network_id
   subnet_zones    = module.network.zone

--- a/module_network/providers.tf
+++ b/module_network/providers.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">=0.13"
     }
   }
   required_version = ">=0.13"

--- a/providers.tf
+++ b/providers.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">=0.13"
     }
   }
   required_version = ">=0.13"

--- a/variables.tf
+++ b/variables.tf
@@ -19,40 +19,8 @@ variable "default_zone" {
   default     = "ru-central1-a"
   description = "https://cloud.yandex.ru/docs/overview/concepts/geo-scope"
 }
-variable "default_cidr" {
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
-
-variable "vpc_name" {
-  type        = string
-  default     = "develop"
-  description = "VPC network&subnet name"
-}
 
 ###common vars
-
-variable "vms_ssh_root_key" {
-  type        = string
-  default     = "your_ssh_ed25519_key"
-  description = "ssh-keygen -t ed25519"
-}
-
-###example vm_web var
-variable "vm_web_name" {
-  type        = string
-  default     = "netology-develop-platform-web"
-  description = "example vm_web_ prefix"
-}
-
-###example vm_db var
-variable "vm_db_name" {
-  type        = string
-  default     = "netology-develop-platform-db"
-  description = "example vm_db_ prefix"
-}
-
 variable "ssh_public_key" {
   type        = string
   default = "/root/.ssh/id_ed25519.pub"


### PR DESCRIPTION
root@Terraform:~/terraform# terraform plan
module.test-vm.data.yandex_compute_image.my_image: Reading...
module.network.yandex_vpc_network.develop: Refreshing state... [id=enpha4eaqvg3ilhenrk5]
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=0b8a625f730e200c058dbe7e5e6ef7c24ac40a8553daf031cf300e043ab1da60]
module.test-vm.data.yandex_compute_image.my_image: Read complete after 1s [id=fd8q5m87s3v0hmp06i5c]
module.network.yandex_vpc_subnet.develop: Refreshing state... [id=e9bsqqmf6muja4rn2lbq]
module.test-vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmb5tkt2d64imer5q7s]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Version constraints inside provider configuration blocks are deprecated
│
│   on .terraform/modules/test-vm/providers.tf line 2, in provider "template":
│    2:   version = "2.2.0"
│
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now
│ deprecated and will be removed in a future version of Terraform. To silence this warning, move the provider version
│ constraint into the required_providers block.
╵
Releasing state lock. This may take a few moments...


root@Terraform:~/terraform# tflint
1 issue(s) found:

main.tf:23:1: Warning - Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)


root@Terraform:~/terraform# checkov -d ~/terraform/
[ kubernetes framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml
[ ansible framework ]:   0%|                    |[0/1], Current File Scanned=cloud-init.yml2023-10-24 23:08:25,491 [MainThread  ] [WARNI]  Failed to download module git::https://github.com/udjin10/yandex_compute_instance.git?ref=e801fb6:None (for external modules, the --download-external-modules flag is required)
[ secrets framework ]: 100%|████████████████████|[9/9], Current File Scanned=/root/terraform/module_network/outputs.tf
[ terraform framework ]: 100%|████████████████████|[8/8], Current File Scanned=variables.tf
[ ansible framework ]: 100%|████████████████████|[1/1], Current File Scanned=cloud-init.yml


       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By bridgecrew.io | version: 2.5.7
Update available 2.5.7 -> 3.0.3
Run pip3 install -U checkov to update


terraform scan results:

Passed checks: 1, Failed checks: 0, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: test-vm
        File: /main.tf:3-17
        Guide: https://docs.paloaltonetworks.com/content/techdocs/en_US/prisma/prisma-cloud/prisma-cloud-code-security-policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision.html
